### PR TITLE
1021465: Add README for getting started with Blazor Kanban component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,40 @@
-# Getting Started with Blazor Kanban Component
+# Getting Started with the Syncfusion Blazor Kanban Component
 
-This sample explains about how to working with the Syncfusion Blazor Kanban component in a Blazor WebAssembly application. This project also contains the code to populate cards and enable Swimlane in the Kanban.
+A minimal Blazor sample demonstrating how to use the Syncfusion Kanban component in a Blazor WebAssembly application. The project includes examples for populating cards, enabling swimlanes, and basic board configuration.
 
-**Documentation**: https://blazor.syncfusion.com/documentation/kanban/getting-started
+## Overview
 
-**Online examples**: https://blazor.syncfusion.com/demos/kanban/overview?theme=bootstrap4
+This sample shows the essential steps to integrate the Syncfusion Kanban component into a Blazor app, including data binding, swimlane setup, and initial card population. Use it as a starting point for building Kanban-driven UIs.
+
+Documentation: https://blazor.syncfusion.com/documentation/kanban/getting-started
+
+Online examples: https://blazor.syncfusion.com/demos/kanban/overview?theme=bootstrap4
+
+## Features
+
+- Basic Kanban setup and configuration
+- Card population and data binding
+- Swimlane enablement and examples
 
 ## Prerequisites
 
-* Visual Studio 2022
+- Visual Studio 2022 (or later)
+- The .NET SDK required by the solution
 
-## How to run the project
+## Run the project
 
-* Checkout this project to a location in your disk.
-* Open the solution file using the Visual Studio 2022.
-* Restore the NuGet packages by rebuilding the solution.
-* Run the project.
+1. Clone the repository to a local folder.
+2. Open the solution in Visual Studio 2022.
+3. Restore NuGet packages by rebuilding the solution or run `dotnet restore`.
+4. Build and run the project from Visual Studio.
+
+Optional CLI commands:
+
+```powershell
+dotnet restore
+dotnet build
+```
+
+## Troubleshooting & support
+
+If you encounter issues, confirm that packages are restored, the project builds, and the license key is registered correctly. For more details about Syncfusion components consult the Syncfusion Blazor documentation.


### PR DESCRIPTION
Updated the README to provide a clear getting‑started guide for the Syncfusion Blazor Kanban component, outlining basic setup, key features, prerequisites, and step‑by‑step instructions to build and run the sample application.